### PR TITLE
Add Insert and Returning clauses with parsing support

### DIFF
--- a/src/Carbunqlex/Clauses/InsertClause.cs
+++ b/src/Carbunqlex/Clauses/InsertClause.cs
@@ -1,0 +1,53 @@
+﻿
+using Carbunqlex.DatasourceExpressions;
+
+namespace Carbunqlex.Clauses;
+
+public class InsertClause : ISqlComponent
+{
+    public TableSource TableSource { get; set; }
+
+    public List<string> ColumnNames { get; set; }
+
+    public InsertClause(TableSource tableSource, List<string> columnNames)
+    {
+        TableSource = tableSource;
+        ColumnNames = columnNames;
+    }
+
+    public InsertClause(TableSource tableSource)
+    {
+        TableSource = tableSource;
+        ColumnNames = new List<string>();
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        yield return new Token(TokenType.Command, "insert into");
+        yield return new Token(TokenType.Identifier, TableSource.TableFullName);
+        if (TableSource.ColumnNames.Any())
+        {
+            yield return new Token(TokenType.OpenParen, "(");
+            foreach (var columnName in TableSource.ColumnNames)
+            {
+                yield return new Token(TokenType.Identifier, columnName);
+                yield return new Token(TokenType.Comma, ",");
+            }
+            yield return new Token(TokenType.CloseBracket, ")");
+        }
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        yield break;
+    }
+
+    public string ToSqlWithoutCte()
+    {
+        if (ColumnNames.Any())
+        {
+            return $"insert into {TableSource.TableFullName}({string.Join(", ", ColumnNames)})";
+        }
+        return $"insert into {TableSource.TableFullName}";
+    }
+}

--- a/src/Carbunqlex/Clauses/ReturningClause.cs
+++ b/src/Carbunqlex/Clauses/ReturningClause.cs
@@ -1,0 +1,74 @@
+﻿using Carbunqlex.ValueExpressions;
+using System.Text;
+
+namespace Carbunqlex.Clauses;
+
+public class ReturningClause : ISqlComponent
+{
+    public List<SelectExpression> Expressions { get; }
+
+    public ReturningClause(params SelectExpression[] selectExpressions)
+    {
+        Expressions = selectExpressions.ToList();
+    }
+
+    public ReturningClause(List<SelectExpression> selectExpressions)
+    {
+        Expressions = selectExpressions;
+    }
+
+    public string ToSqlWithoutCte()
+    {
+        var sb = new StringBuilder();
+        sb.Append("returning");
+
+        if (Expressions.Count == 0)
+        {
+            sb.Append(" *");
+        }
+        else
+        {
+            sb.Append(" ");
+            for (var i = 0; i < Expressions.Count; i++)
+            {
+                sb.Append(Expressions[i].ToSqlWithoutCte());
+                if (i < Expressions.Count - 1)
+                {
+                    sb.Append(", ");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        var tokens = new List<Token>();
+        tokens.Add(new Token(TokenType.Command, "returning"));
+
+        if (Expressions.Count == 0)
+        {
+            tokens.Add(new Token(TokenType.Identifier, "*"));
+        }
+        else
+        {
+            foreach (var column in Expressions)
+            {
+                tokens.AddRange(column.GenerateTokensWithoutCte());
+            }
+        }
+
+        return tokens;
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        yield break;
+    }
+
+    public IEnumerable<ColumnExpression> ExtractColumnExpressions()
+    {
+        yield break;
+    }
+}

--- a/src/Carbunqlex/InsertQuery.cs
+++ b/src/Carbunqlex/InsertQuery.cs
@@ -1,0 +1,115 @@
+﻿using Carbunqlex.Clauses;
+using Carbunqlex.ValueExpressions;
+using System.Text;
+
+namespace Carbunqlex;
+
+public class InsertQuery : IQuery
+{
+    public InsertClause InsertClause { get; set; }
+
+    public ISelectQuery SelectQuery { get; set; }
+
+    public Dictionary<string, object?> Parameters { get; } = new();
+
+    public ReturningClause? Returning { get; set; }
+
+    public InsertQuery(InsertClause insertClause, ISelectQuery selectQuery, ReturningClause? returning = null)
+    {
+        InsertClause = insertClause;
+        SelectQuery = selectQuery;
+        Returning = returning;
+    }
+
+    public string ToSqlWithoutCte()
+    {
+        var sb = new StringBuilder($"{InsertClause.ToSqlWithoutCte()} {SelectQuery.ToSqlWithoutCte()}");
+        if (Returning != null)
+        {
+            sb.Append($" {Returning.ToSqlWithoutCte()}");
+        }
+        return sb.ToString();
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        foreach (var token in InsertClause.GenerateTokensWithoutCte())
+        {
+            yield return token;
+        }
+        foreach (var token in SelectQuery.GenerateTokensWithoutCte())
+        {
+            yield return token;
+        }
+        if (Returning != null)
+        {
+            foreach (var token in Returning.GenerateTokensWithoutCte())
+            {
+                yield return token;
+            }
+        }
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        yield return SelectQuery;
+    }
+
+    public string ToSql()
+    {
+        var sb = new StringBuilder();
+        var cteClauses = GetCommonTableClauses().ToList();
+        if (cteClauses.Any())
+        {
+            sb.Append("with ");
+            sb.Append(string.Join(", ", cteClauses.Select(cte => cte.ToSqlWithoutCte())));
+            sb.Append(" ");
+        }
+        sb.Append(ToSqlWithoutCte());
+        return sb.ToString();
+    }
+
+    public IEnumerable<Token> GenerateTokens()
+    {
+        var cteClauses = GetCommonTableClauses().ToList();
+        if (cteClauses.Any())
+        {
+            yield return new Token(TokenType.Command, "with");
+            foreach (var cte in cteClauses)
+            {
+                foreach (var token in cte.GenerateTokensWithoutCte())
+                {
+                    yield return token;
+                }
+            }
+        }
+        foreach (var token in GenerateTokensWithoutCte())
+        {
+            yield return token;
+        }
+        if (Returning != null)
+        {
+            foreach (var token in Returning.GenerateTokensWithoutCte())
+            {
+                yield return token;
+            }
+        }
+    }
+
+    public IEnumerable<CommonTableClause> GetCommonTableClauses()
+    {
+        return SelectQuery.GetCommonTableClauses();
+    }
+
+    public IDictionary<string, object?> GetParameters()
+    {
+        return Parameters;
+    }
+
+    public ParameterExpression AddParameter(string name, object value)
+    {
+        var parameter = new ParameterExpression(name);
+        Parameters[name] = value;
+        return parameter;
+    }
+}

--- a/src/Carbunqlex/Parsing/InsertQueryParser.cs
+++ b/src/Carbunqlex/Parsing/InsertQueryParser.cs
@@ -1,0 +1,156 @@
+﻿using Carbunqlex.Clauses;
+using Carbunqlex.DatasourceExpressions;
+using Carbunqlex.Parsing.ValueExpression;
+
+namespace Carbunqlex.Parsing;
+
+/// <summary>
+/// Parses INSERT queries from SQL tokens.
+/// </summary>
+public static class InsertQueryParser
+{
+    /// <summary>
+    /// Parse INSERT query from SQL string.
+    /// </summary>
+    /// <param name="sql"></param>
+    /// <returns></returns>
+    public static InsertQuery Parse(string sql)
+    {
+        return Parse(new SqlTokenizer(sql));
+    }
+
+    /// <summary>
+    /// Parse INSERT query from SQL tokenizer.
+    /// </summary>
+    /// <param name="tokenizer"></param>
+    /// <returns></returns>
+    public static InsertQuery Parse(SqlTokenizer tokenizer)
+    {
+        tokenizer.Read("insert into");
+
+        // Parse InsertClause
+        var insertClause = ParseInsertClause(tokenizer);
+
+        // Parse SelectQuery
+        var selectQuery = SelectQueryParser.ParseWithoutEndCheck(tokenizer);
+
+        if (tokenizer.IsEnd)
+        {
+            var insertQuery = new InsertQuery(insertClause, selectQuery);
+            return insertQuery;
+        }
+        else if (tokenizer.Peek().CommandOrOperatorText == "returning")
+        {
+            tokenizer.CommitPeek();
+            var returning = ParseReturningClause(tokenizer);
+
+            var insertQuery = new InsertQuery(insertClause, selectQuery, returning);
+            if (tokenizer.IsEnd)
+            {
+                return insertQuery;
+            }
+            // Error if there are unparsed tokens left
+            throw SqlParsingExceptionBuilder.Interrupted(tokenizer, insertQuery.ToSql());
+        }
+        else
+        {
+            var insertQuery = new InsertQuery(insertClause, selectQuery);
+            // Error if there are unparsed tokens left
+            throw SqlParsingExceptionBuilder.Interrupted(tokenizer, insertQuery.ToSql());
+        }
+    }
+
+    /// <summary>
+    /// Parse InsertClause
+    /// </summary>
+    /// <param name="tokenizer"></param>
+    /// <returns></returns>
+    private static InsertClause ParseInsertClause(SqlTokenizer tokenizer)
+    {
+        // Parse table name and column names
+        var tableSource = ParseTableSource(tokenizer);
+
+        // Read column names (optional)
+        var columnNames = new List<string>();
+
+        if (tokenizer.Peek().Type == TokenType.OpenParen)
+        {
+            tokenizer.CommitPeek();
+            while (true)
+            {
+                var columnName = tokenizer.Read(TokenType.Identifier).Value;
+                columnNames.Add(columnName);
+                if (tokenizer.Peek().Type == TokenType.Comma)
+                {
+                    tokenizer.CommitPeek();
+                    continue;
+                }
+                else if (tokenizer.Peek().Type == TokenType.CloseParen)
+                {
+                    break;
+                }
+                throw SqlParsingExceptionBuilder.UnexpectedTokenType(tokenizer, [TokenType.Comma, TokenType.CloseParen], tokenizer.Peek());
+            }
+            tokenizer.Read(TokenType.CloseParen);
+        }
+
+        // Create InsertClause
+        return new InsertClause(tableSource, columnNames);
+    }
+
+    /// <summary>
+    /// Parse table source
+    /// </summary>
+    /// <param name="tokenizer"></param>
+    /// <returns></returns>
+    private static TableSource ParseTableSource(SqlTokenizer tokenizer)
+    {
+        var items = new List<string>();
+
+        while (true)
+        {
+            var identifier = tokenizer.Read(TokenType.Identifier).Value;
+            items.Add(identifier);
+            if (tokenizer.Peek().Type == TokenType.Dot)
+            {
+                tokenizer.CommitPeek();
+                continue;
+            }
+            break;
+        }
+
+        if (items.Count == 0)
+        {
+            throw SqlParsingExceptionBuilder.UnexpectedTokenType(tokenizer, TokenType.Identifier, tokenizer.Peek());
+        }
+        else if (items.Count == 1)
+        {
+            return new TableSource(items[0]);
+        }
+        else
+        {
+            return new TableSource(items.Take(items.Count - 1).ToList(), items.Last());
+        }
+    }
+
+    private static ReturningClause ParseReturningClause(SqlTokenizer tokenizer)
+    {
+        // Parse expressions
+        var expressions = new List<SelectExpression>();
+        while (true)
+        {
+            expressions.Add(SelectExpressionParser.Parse(tokenizer));
+            if (tokenizer.IsEnd)
+            {
+                break;
+            }
+            if (tokenizer.Peek().Type == TokenType.Comma)
+            {
+                tokenizer.CommitPeek();
+                continue;
+            }
+            break;
+        }
+        return new ReturningClause(expressions);
+    }
+}

--- a/src/Carbunqlex/Parsing/SelectQueryParser.cs
+++ b/src/Carbunqlex/Parsing/SelectQueryParser.cs
@@ -103,7 +103,7 @@ public static class SelectQueryParser
             {
                 tokenizer.CommitPeek();
                 continue;
-            };
+            }
             break;
         }
     }

--- a/src/Carbunqlex/SelectQuery.cs
+++ b/src/Carbunqlex/SelectQuery.cs
@@ -20,6 +20,10 @@ public class SelectQuery : ISelectQuery
     public OffsetClause? OffsetClause { get; set; }
     public IForClause? ForClause { get; set; }
 
+    public Dictionary<string, object?> Parameters { get; } = new();
+
+    public bool MightHaveQueries => true;
+
     public SelectQuery(SelectClause selectClause)
     {
         SelectClause = selectClause;
@@ -200,9 +204,6 @@ public class SelectQuery : ISelectQuery
 
         return queries;
     }
-
-    public Dictionary<string, object?> Parameters { get; } = new();
-    public bool MightHaveQueries => true;
 
     public IDictionary<string, object?> GetParameters()
     {

--- a/tests/Carbunqlex.Tests/ParsingTests/InsertQueryParserTest.cs
+++ b/tests/Carbunqlex.Tests/ParsingTests/InsertQueryParserTest.cs
@@ -1,0 +1,53 @@
+﻿using Carbunqlex.Parsing;
+using Carbunqlex.Parsing.ValueExpression;
+using Xunit.Abstractions;
+
+namespace Carbunqlex.Tests.ParsingTests;
+
+public class InsertQueryParserTest
+{
+    private readonly ITestOutputHelper Output;
+
+    public InsertQueryParserTest(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    [Fact]
+    public void ParseBasicInsertQuery()
+    {
+        var sql = "insert into table_name(column1, column2) values (1, 'value')";
+        var result = InsertQueryParser.Parse(sql);
+        var actual = result.ToSqlWithoutCte();
+        Output.WriteLine(actual);
+        Assert.Equal("insert into table_name(column1, column2) values (1, 'value')", actual);
+    }
+
+    [Fact]
+    public void ParseInsertQueryWithReturning()
+    {
+        var sql = "insert into table_name(column1, column2) values (1, 'value') returning id";
+        var result = InsertQueryParser.Parse(sql);
+        var actual = result.ToSqlWithoutCte();
+        Output.WriteLine(actual);
+        Assert.Equal("insert into table_name(column1, column2) values (1, 'value') returning id", actual);
+    }
+
+    [Fact]
+    public void ParseInsertQueryWithSelect()
+    {
+        var sql = "insert into table_name(column1, column2) select column1, column2 from other_table";
+        var result = InsertQueryParser.Parse(sql);
+        var actual = result.ToSqlWithoutCte();
+        Output.WriteLine(actual);
+        Assert.Equal("insert into table_name(column1, column2) select column1, column2 from other_table", actual);
+    }
+
+    [Fact]
+    public void ParseInvalidInsertQuery()
+    {
+        // Missing '(' after table_name
+        var sql = "insert into table_name column1, column2 values (1, 'value')";
+        Assert.Throws<SqlParsingException>(() => InsertQueryParser.Parse(sql));
+    }
+}


### PR DESCRIPTION
- Implemented `InsertClause` class for generating insert statements.
- Added `ReturningClause` class to handle RETURNING clauses.
- Created `InsertQuery` class to represent insert queries with SQL generation methods.
- Introduced `InsertQueryParser` class for parsing insert queries from SQL tokens.
- Added unit tests in `InsertQueryParserTest` for various insert query scenarios.