### PR TITLE
Add delete query generation and related enhancements

### DIFF
--- a/src/Carbunqlex/Clauses/DeleteClause.cs
+++ b/src/Carbunqlex/Clauses/DeleteClause.cs
@@ -11,7 +11,9 @@ public class DeleteClause : ISqlComponent
     public DeleteClause(TableSource tableSource, string alias)
     {
         TableSource = tableSource;
-        Alias = alias;
+        Alias = string.IsNullOrEmpty(alias)
+            ? tableSource.DefaultName
+            : alias;
     }
 
     public DeleteClause(TableSource tableSource)

--- a/src/Carbunqlex/Parsing/ValueArgumentsParser.cs
+++ b/src/Carbunqlex/Parsing/ValueArgumentsParser.cs
@@ -5,7 +5,7 @@ namespace Carbunqlex.Parsing;
 
 public static class ValueArgumentsParser
 {
-    public static ValueArguments Parse(SqlTokenizer tokenizer, TokenType openToken, TokenType closeToken)
+    public static ArgumentExpression Parse(SqlTokenizer tokenizer, TokenType openToken, TokenType closeToken)
     {
         tokenizer.Read(openToken);
 
@@ -27,13 +27,13 @@ public static class ValueArgumentsParser
             if (token.Type == closeToken)
             {
                 tokenizer.Read();
-                return new ValueArguments(args);
+                return new ArgumentExpression(args);
             }
 
             if (token.CommandOrOperatorText == "order by")
             {
                 var orderByClause = OrderByClauseParser.Parse(tokenizer);
-                var expression = new ValueArguments(args) { OrderByClause = orderByClause };
+                var expression = new ArgumentExpression(args) { OrderByClause = orderByClause };
                 tokenizer.Read(closeToken);
                 return expression;
             }

--- a/src/Carbunqlex/Parsing/ValueExpression/ExistsExpressionParser.cs
+++ b/src/Carbunqlex/Parsing/ValueExpression/ExistsExpressionParser.cs
@@ -1,0 +1,25 @@
+﻿using Carbunqlex.ValueExpressions;
+
+namespace Carbunqlex.Parsing.ValueExpression;
+
+public static class ExistsExpressionParser
+{
+    public static ExistsExpression Parse(SqlTokenizer tokenizer)
+    {
+        var isNegated = tokenizer.Read(TokenType.Command, token =>
+        {
+            return token.CommandOrOperatorText switch
+            {
+                "exists" => false,
+                "not exists" => true,
+                _ => throw SqlParsingExceptionBuilder.UnexpectedToken(tokenizer, ["exists", "not exists"], token)
+            };
+        });
+
+        tokenizer.Read(TokenType.OpenParen);
+        var query = SelectQueryParser.ParseWithoutEndCheck(tokenizer);
+        tokenizer.Read(TokenType.CloseParen);
+
+        return new ExistsExpression(isNegated, query);
+    }
+}

--- a/src/Carbunqlex/Parsing/ValueExpression/FunctionExpressionParser.cs
+++ b/src/Carbunqlex/Parsing/ValueExpression/FunctionExpressionParser.cs
@@ -50,12 +50,12 @@ public static class FunctionExpressionParser
         return new FunctionExpression(function.Value, prefixModifier, args);
     }
 
-    private static ValueArguments ParseArguments(SqlTokenizer tokenizer)
+    private static ArgumentExpression ParseArguments(SqlTokenizer tokenizer)
     {
         // no arguments
         if (tokenizer.Peek().Type == TokenType.CloseParen)
         {
-            return new ValueArguments();
+            return new ArgumentExpression();
         }
 
         var args = new List<IValueExpression>();
@@ -78,9 +78,9 @@ public static class FunctionExpressionParser
         if (next.CommandOrOperatorText == "order by")
         {
             var orderBy = OrderByClauseParser.Parse(tokenizer);
-            return new ValueArguments(args, orderBy);
+            return new ArgumentExpression(args, orderBy);
         }
 
-        return new ValueArguments(args);
+        return new ArgumentExpression(args);
     }
 }

--- a/src/Carbunqlex/Parsing/ValueExpression/InExpressionParser.cs
+++ b/src/Carbunqlex/Parsing/ValueExpression/InExpressionParser.cs
@@ -24,7 +24,7 @@ public static class InExpressionParser
         {
             var query = SelectQueryParser.ParseWithoutEndCheck(tokenizer);
             tokenizer.Read(TokenType.CloseParen);
-            return new InExpression(isNegated, left, query);
+            return new InExpression(isNegated, left, new SubQueryExpression(query));
         }
         else
         {
@@ -34,7 +34,7 @@ public static class InExpressionParser
         }
     }
 
-    public static ValueArguments ParseAsArguments(SqlTokenizer tokenizer)
+    private static InValueGroupExpression ParseAsArguments(SqlTokenizer tokenizer)
     {
         var args = new List<IValueExpression>();
         while (true)
@@ -49,30 +49,6 @@ public static class InExpressionParser
             break;
         }
 
-        return new ValueArguments(args);
-    }
-}
-
-
-
-public static class ExistsExpressionParser
-{
-    public static ExistsExpression Parse(SqlTokenizer tokenizer)
-    {
-        var isNegated = tokenizer.Read(TokenType.Command, token =>
-        {
-            return token.CommandOrOperatorText switch
-            {
-                "exists" => false,
-                "not exists" => true,
-                _ => throw SqlParsingExceptionBuilder.UnexpectedToken(tokenizer, ["exists", "not exists"], token)
-            };
-        });
-
-        tokenizer.Read(TokenType.OpenParen);
-        var query = SelectQueryParser.ParseWithoutEndCheck(tokenizer);
-        tokenizer.Read(TokenType.CloseParen);
-
-        return new ExistsExpression(isNegated, query);
+        return new InValueGroupExpression(args);
     }
 }

--- a/src/Carbunqlex/Parsing/ValueExpression/ParenthesizedExpressionParser.cs
+++ b/src/Carbunqlex/Parsing/ValueExpression/ParenthesizedExpressionParser.cs
@@ -16,9 +16,23 @@ public class ParenthesizedExpressionParser
         }
         else
         {
-            var value = ValueExpressionParser.Parse(tokenizer);
+            var values = new List<IValueExpression>() {
+                ValueExpressionParser.Parse(tokenizer)
+            };
+            while (tokenizer.TryPeek(out var comma) && comma.Type == TokenType.Comma)
+            {
+                tokenizer.CommitPeek();
+                values.Add(ValueExpressionParser.Parse(tokenizer));
+            }
             tokenizer.Read(TokenType.CloseParen);
-            return new ParenthesizedExpression(value);
+            if (values.Count == 1)
+            {
+                return new ParenthesizedExpression(values[0]);
+            }
+            else
+            {
+                return new InValueGroupExpression(values);
+            }
         }
     }
 }

--- a/src/Carbunqlex/QueryNodeFactory.cs
+++ b/src/Carbunqlex/QueryNodeFactory.cs
@@ -1,9 +1,16 @@
 ﻿using Carbunqlex.Clauses;
+using Carbunqlex.Parsing;
 
 namespace Carbunqlex;
 
 public class QueryNodeFactory
 {
+    public static QueryNode Create(string sql)
+    {
+        var query = SelectQueryParser.Parse(sql);
+        return Create(query);
+    }
+
     public static QueryNode Create(ISelectQuery query)
     {
         var ctes = query.GetCommonTableClauses().ToList();

--- a/src/Carbunqlex/ValueBuilder.cs
+++ b/src/Carbunqlex/ValueBuilder.cs
@@ -40,35 +40,35 @@ public static class ValueBuilder
         return new BetweenExpression(true, left, start, end);
     }
 
-    public static InExpression In(IValueExpression left, IArgumentExpression right)
+    public static InExpression In(IValueGroupExpression left, IValueGroupExpression right)
     {
         return new InExpression(false, left, right);
     }
 
-    public static InExpression In(IValueExpression left, params object[] values)
-    {
-        return In(left, ConstantSet(values));
-    }
+    //public static InExpression In(IValueExpression left, params object[] values)
+    //{
+    //    return In(new InClauseValueExpression(left), new InClauseValueExpression(CreateConstantList(values)));
+    //}
 
-    public static InExpression In(IValueExpression left, ISelectQuery scalarSubQuery)
-    {
-        return In(left, scalarSubQuery);
-    }
+    //public static InExpression In(IValueExpression left, ISelectQuery scalarSubQuery)
+    //{
+    //    return In(new InClauseValueExpression(left), new InClauseQueryExpression(scalarSubQuery));
+    //}
 
-    public static InExpression NotIn(IValueExpression left, IArgumentExpression right)
+    public static InExpression NotIn(IValueGroupExpression left, IValueGroupExpression right)
     {
         return new InExpression(true, left, right);
     }
 
-    public static InExpression NotIn(IValueExpression left, params object[] values)
-    {
-        return NotIn(left, ConstantSet(values));
-    }
+    //public static InExpression NotIn(IValueExpression left, params object[] values)
+    //{
+    //    return NotIn(new InClauseValueExpression(left), new InClauseValueExpression(CreateConstantList(values)));
+    //}
 
-    public static InExpression NotIn(IValueExpression left, ISelectQuery scalarSubQuery)
-    {
-        return NotIn(left, scalarSubQuery);
-    }
+    //public static InExpression NotIn(IValueExpression left, ISelectQuery scalarSubQuery)
+    //{
+    //    return NotIn(new InClauseValueExpression(left), new InClauseQueryExpression(scalarSubQuery));
+    //}
 
     public static LikeExpression Like(IValueExpression left, IValueExpression right)
     {
@@ -97,60 +97,66 @@ public static class ValueBuilder
 
     public static FunctionExpression Function(string functionName, IEnumerable<IValueExpression> arguments, OverClause? overClause = null)
     {
-        return new FunctionExpression(functionName, string.Empty, new ValueArguments(arguments), overClause);
+        return new FunctionExpression(functionName, string.Empty, new ArgumentExpression(arguments), overClause);
     }
 
     public static FunctionExpression Function(string functionName, params IValueExpression[] arguments)
     {
-        return new FunctionExpression(functionName, string.Empty, new ValueArguments(arguments));
+        return new FunctionExpression(functionName, string.Empty, new ArgumentExpression(arguments));
     }
 
-    public static ValueArguments ConstantSet(params object[] values)
+    internal static InValueGroupExpression CreateInClauseValueExpression(IEnumerable<object> values)
     {
         var expressions = values.ToList().Select(static v => v is IValueExpression expr ? expr : Constant(v));
-        return new ValueArguments(expressions);
+        return new InValueGroupExpression(expressions.ToList());
+    }
+
+    internal static ArgumentExpression CreateConstantArguments(params object[] values)
+    {
+        var expressions = values.ToList().Select(static v => v is IValueExpression expr ? expr : Constant(v));
+        return new ArgumentExpression(expressions);
     }
 
     public static ArrayExpression Array(params object[] values)
     {
         var expressions = values.ToList().Select(static v => v is IValueExpression expr ? expr : Constant(v));
-        return new ArrayExpression(new ValueArguments(expressions));
+        return new ArrayExpression(new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Greatest(IEnumerable<object> values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("greatest", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("greatest", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Greatest(params object[] values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("greatest", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("greatest", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Least(IEnumerable<object> values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("least", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("least", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Least(params object[] values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("least", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("least", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Coalesce(IEnumerable<object> values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("coalesce", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("coalesce", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static FunctionExpression Coalesce(params object[] values)
     {
         var expressions = values.Select(v => v is IValueExpression expr ? expr : Constant(v));
-        return new FunctionExpression("coalesce", string.Empty, new ValueArguments(expressions));
+        return new FunctionExpression("coalesce", string.Empty, new ArgumentExpression(expressions));
     }
 
     public static IValueExpression Keyword(string v)

--- a/src/Carbunqlex/ValueExpressions/ArgumentExpression.cs
+++ b/src/Carbunqlex/ValueExpressions/ArgumentExpression.cs
@@ -1,0 +1,102 @@
+﻿using Carbunqlex.Clauses;
+using Carbunqlex.ValueExpressions;
+using System.Text;
+
+namespace Carbunqlex.ValueExpressions;
+
+public interface IArgumentExpression : ISqlComponent
+{
+    bool MightHaveQueries { get; }
+    IEnumerable<ColumnExpression> ExtractColumnExpressions();
+}
+
+/// <summary>
+/// Represents a list of values for a function or operator.
+/// </summary>
+public class ArgumentExpression : IArgumentExpression
+{
+    public List<IValueExpression> Values { get; }
+
+    /// <summary>
+    /// Optional ORDER BY clause for the arguments.
+    /// e.g. array_agg(value order by sort_column)
+    /// </summary>
+    public OrderByClause? OrderByClause { get; set; }
+
+    public ArgumentExpression(params IValueExpression[] values)
+    {
+        Values = values.ToList();
+        OrderByClause = null;
+    }
+
+    public ArgumentExpression(IEnumerable<IValueExpression> values)
+    {
+        Values = values.ToList();
+        OrderByClause = null;
+    }
+
+    public ArgumentExpression(List<IValueExpression> values)
+    {
+        Values = values;
+        OrderByClause = null;
+    }
+
+    /// <summary>
+    /// Constructor for ORDER BY clause.
+    /// e.g. array_agg(value order by sort_column)
+    /// </summary>
+    /// <param name="values"></param>
+    /// <param name="orderBy"></param>
+    public ArgumentExpression(List<IValueExpression> values, OrderByClause orderBy)
+    {
+        Values = values;
+        OrderByClause = orderBy;
+    }
+
+    public bool MightHaveQueries => Values.Any(v => v.MightHaveQueries);
+
+    public string ToSqlWithoutCte()
+    {
+        var sb = new StringBuilder();
+        sb.Append(string.Join(", ", Values.Select(v => v.ToSqlWithoutCte())));
+        if (OrderByClause != null)
+        {
+            sb.Append(" ").Append(OrderByClause.ToSqlWithoutCte());
+        }
+        return sb.ToString();
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        foreach (var value in Values)
+        {
+            foreach (var lexeme in value.GenerateTokensWithoutCte())
+            {
+                yield return lexeme;
+            }
+        }
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        var queries = new List<ISelectQuery>();
+        foreach (var value in Values)
+        {
+            if (value.MightHaveQueries)
+            {
+                queries.AddRange(value.GetQueries());
+            }
+        }
+        return queries;
+    }
+
+    public IEnumerable<ColumnExpression> ExtractColumnExpressions()
+    {
+        var columns = new List<ColumnExpression>();
+        foreach (var value in Values)
+        {
+            columns.AddRange(value.ExtractColumnExpressions());
+        }
+        return columns;
+    }
+}

--- a/src/Carbunqlex/ValueExpressions/IValueExpression.cs
+++ b/src/Carbunqlex/ValueExpressions/IValueExpression.cs
@@ -58,23 +58,23 @@ public static class IValueExpressionExtensions
     public static LikeExpression NotLike(this IValueExpression left, object right) =>
         NotLike(left, ValueBuilder.Constant(right));
 
-    public static InExpression In(this IValueExpression left, IArgumentExpression right) =>
-        ValueBuilder.In(left, right);
+    public static InExpression In(this IValueExpression left, IValueGroupExpression right) =>
+        ValueBuilder.In(new InValueGroupExpression(left), right);
 
-    public static InExpression In(this IValueExpression left, params object[] values) =>
-        ValueBuilder.In(left, ValueBuilder.ConstantSet(values));
+    public static InExpression In(this IValueExpression left, IEnumerable<object> values) =>
+        ValueBuilder.In(new InValueGroupExpression(left), ValueBuilder.CreateInClauseValueExpression(values));
 
     public static InExpression In(this IValueExpression left, ISelectQuery right) =>
-        ValueBuilder.In(left, right);
+        ValueBuilder.In(new InValueGroupExpression(left), new SubQueryExpression(right));
 
-    public static InExpression NotIn(this IValueExpression left, IArgumentExpression right) =>
-        ValueBuilder.NotIn(left, right);
+    public static InExpression NotIn(this IValueExpression left, IValueGroupExpression right) =>
+        ValueBuilder.NotIn(new InValueGroupExpression(left), right);
 
-    public static InExpression NotIn(this IValueExpression left, params object[] values) =>
-        ValueBuilder.NotIn(left, ValueBuilder.ConstantSet(values));
+    public static InExpression NotIn(this IValueExpression left, IEnumerable<object> values) =>
+        ValueBuilder.NotIn(new InValueGroupExpression(left), ValueBuilder.CreateInClauseValueExpression(values));
 
     public static InExpression NotIn(this IValueExpression left, ISelectQuery right) =>
-        ValueBuilder.NotIn(left, right);
+        ValueBuilder.NotIn(new InValueGroupExpression(left), new SubQueryExpression(right));
 
     public static BinaryExpression IsNull(this IValueExpression expression) =>
         new BinaryExpression("is", expression, ValueBuilder.Null);
@@ -131,7 +131,7 @@ public static class IValueExpressionExtensions
     }
 
     public static FunctionExpression Greatest(this IValueExpression left, params IValueExpression[] values) =>
-        Greatest(left, new ValueArguments(values));
+        Greatest(left, new ArgumentExpression(values));
 
     public static FunctionExpression Least(this IValueExpression left, params object[] values)
     {
@@ -139,5 +139,5 @@ public static class IValueExpressionExtensions
     }
 
     public static FunctionExpression Least(this IValueExpression left, params IValueExpression[] values) =>
-        Least(left, new ValueArguments(values));
+        Least(left, new ArgumentExpression(values));
 }

--- a/src/Carbunqlex/ValueExpressions/IValueGroupExpression.cs
+++ b/src/Carbunqlex/ValueExpressions/IValueGroupExpression.cs
@@ -1,0 +1,152 @@
+﻿namespace Carbunqlex.ValueExpressions;
+
+/// <summary>
+/// Represents an IN clause value expression. 
+/// </summary>
+public interface IValueGroupExpression : IValueExpression
+{
+}
+
+/// <summary>
+/// Represents an IN clause value expression.
+/// </summary>
+public class InValueGroupExpression : IValueGroupExpression
+{
+    public List<IValueExpression> Arguments { get; }
+
+    public InValueGroupExpression(List<IValueExpression> arguments)
+    {
+        Arguments = arguments;
+    }
+
+    public InValueGroupExpression(params IValueExpression[] arguments)
+    {
+        Arguments = arguments.ToList();
+    }
+
+    public InValueGroupExpression(IValueExpression argument)
+    {
+        Arguments = new List<IValueExpression> { argument };
+    }
+
+    public string DefaultName => string.Empty;
+
+    public bool MightHaveQueries => Arguments.Any(arg => arg.MightHaveQueries);
+
+    public IEnumerable<ColumnExpression> ExtractColumnExpressions()
+    {
+        foreach (var argument in Arguments)
+        {
+            foreach (var columnExpression in argument.ExtractColumnExpressions())
+            {
+                yield return columnExpression;
+            }
+        }
+    }
+
+    public string ToSqlWithoutCte()
+    {
+        if (Arguments.Count == 0)
+        {
+            throw new InvalidOperationException("IN clause must have at least one argument.");
+        }
+        else if (Arguments.Count == 1)
+        {
+            return Arguments[0].ToSqlWithoutCte();
+        }
+        else
+        {
+            return "(" + string.Join(", ", Arguments.Select(arg => arg.ToSqlWithoutCte())) + ")";
+        }
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        if (Arguments.Count == 0)
+        {
+            throw new InvalidOperationException("IN clause must have at least one argument.");
+        }
+        else if (Arguments.Count == 1)
+        {
+            foreach (var token in Arguments[0].GenerateTokensWithoutCte())
+            {
+                yield return token;
+            }
+        }
+        else
+        {
+            yield return new Token(TokenType.OpenParen, "(");
+            foreach (var argument in Arguments)
+            {
+                foreach (var token in argument.GenerateTokensWithoutCte())
+                {
+                    yield return token;
+                }
+                yield return new Token(TokenType.Comma, ",");
+            }
+            yield return new Token(TokenType.CloseParen, ")");
+        }
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        foreach (var argument in Arguments)
+        {
+            foreach (var query in argument.GetQueries())
+            {
+                yield return query;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Represents an IN clause value expression that is a subquery.
+/// 
+/// Similar classes:
+/// ・ISelectQuery
+/// Implements IArgumentExpression, so it can be used as an argument for the any function.
+/// Does not hold parentheses.
+/// Can be used generically.
+/// ・SubQueryExpression
+/// Implements IValueGroupExpression, so it can be used as an argument for the IN clause.
+/// Holds parentheses.
+/// </summary>
+public class SubQueryExpression : IValueGroupExpression
+{
+    public ISelectQuery Query { get; }
+
+    public SubQueryExpression(ISelectQuery query)
+    {
+        Query = query;
+    }
+
+    public string DefaultName => string.Empty;
+
+    public bool MightHaveQueries => true;
+
+    public IEnumerable<ColumnExpression> ExtractColumnExpressions()
+    {
+        yield break;
+    }
+
+    public string ToSqlWithoutCte()
+    {
+        return "(" + Query.ToSqlWithoutCte() + ")";
+    }
+
+    public IEnumerable<Token> GenerateTokensWithoutCte()
+    {
+        yield return new Token(TokenType.OpenParen, "(");
+        foreach (var token in Query.GenerateTokensWithoutCte())
+        {
+            yield return token;
+        }
+        yield return new Token(TokenType.CloseParen, ")");
+    }
+
+    public IEnumerable<ISelectQuery> GetQueries()
+    {
+        yield return Query;
+    }
+}

--- a/src/Carbunqlex/WhereEditor.cs
+++ b/src/Carbunqlex/WhereEditor.cs
@@ -91,7 +91,7 @@ public class WhereEditor
         return this;
     }
 
-    public WhereEditor In(params object[] values)
+    public WhereEditor In(IEnumerable<object> values)
     {
         AddCondition(Value.In(values));
         return this;
@@ -103,13 +103,13 @@ public class WhereEditor
         return this;
     }
 
-    public WhereEditor In(IArgumentExpression rightValue)
+    public WhereEditor In(IValueGroupExpression rightValue)
     {
         AddCondition(Value.In(rightValue));
         return this;
     }
 
-    public WhereEditor NotIn(params object[] values)
+    public WhereEditor NotIn(IEnumerable<object> values)
     {
         AddCondition(Value.NotIn(values));
         return this;
@@ -121,7 +121,7 @@ public class WhereEditor
         return this;
     }
 
-    public WhereEditor NotIn(IArgumentExpression rightValue)
+    public WhereEditor NotIn(IValueGroupExpression rightValue)
     {
         AddCondition(Value.NotIn(rightValue));
         return this;

--- a/tests/Carbunqlex.Tests/ParsingTests/InExpressionParserTests.cs
+++ b/tests/Carbunqlex.Tests/ParsingTests/InExpressionParserTests.cs
@@ -28,7 +28,7 @@ public class InExpressionParserTests
         Assert.IsType<InExpression>(result);
         Assert.False(((InExpression)result).IsNegated);
         Assert.Equal("column", ((InExpression)result).Left.ToSqlWithoutCte());
-        Assert.Equal("1, 2, 3", ((InExpression)result).Right.ToSqlWithoutCte());
+        Assert.Equal("(1, 2, 3)", ((InExpression)result).Right.ToSqlWithoutCte());
         Assert.Equal("column in (1, 2, 3)", result.ToSqlWithoutCte());
     }
 
@@ -47,7 +47,41 @@ public class InExpressionParserTests
         Assert.IsType<InExpression>(result);
         Assert.True(((InExpression)result).IsNegated);
         Assert.Equal("column", ((InExpression)result).Left.ToSqlWithoutCte());
-        Assert.Equal("1, 2, 3", ((InExpression)result).Right.ToSqlWithoutCte());
+        Assert.Equal("(1, 2, 3)", ((InExpression)result).Right.ToSqlWithoutCte());
         Assert.Equal("column not in (1, 2, 3)", result.ToSqlWithoutCte());
+    }
+
+    [Fact]
+    public void Parse_InExpression_WithSubquery_ReturnsCorrectExpression_SingleColumn()
+    {
+        // Arrange
+        var tokenizer = new SqlTokenizer("a.c1 in (select b.c1 from table_b as b)");
+        // Act
+        var result = ValueExpressionParser.Parse(tokenizer);
+        Output.WriteLine(result.ToSqlWithoutCte());
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<InExpression>(result);
+        Assert.False(((InExpression)result).IsNegated);
+        Assert.Equal("a.c1", ((InExpression)result).Left.ToSqlWithoutCte());
+        Assert.Equal("(select b.c1 from table_b as b)", ((InExpression)result).Right.ToSqlWithoutCte());
+        Assert.Equal("a.c1 in (select b.c1 from table_b as b)", result.ToSqlWithoutCte());
+    }
+
+    [Fact]
+    public void Parse_InExpression_WithSubquery_ReturnsCorrectExpression_MultipleColumns()
+    {
+        // Arrange
+        var tokenizer = new SqlTokenizer("(a.c1, a.c2) in (select b.c1, b.c2 from table_b as b)");
+        // Act
+        var result = ValueExpressionParser.Parse(tokenizer);
+        Output.WriteLine(result.ToSqlWithoutCte());
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<InExpression>(result);
+        Assert.False(((InExpression)result).IsNegated);
+        Assert.Equal("(a.c1, a.c2)", ((InExpression)result).Left.ToSqlWithoutCte());
+        Assert.Equal("(select b.c1, b.c2 from table_b as b)", ((InExpression)result).Right.ToSqlWithoutCte());
+        Assert.Equal("(a.c1, a.c2) in (select b.c1, b.c2 from table_b as b)", result.ToSqlWithoutCte());
     }
 }

--- a/tests/Carbunqlex.Tests/QueryNodeTests/PostgresJsonEditorTests.cs
+++ b/tests/Carbunqlex.Tests/QueryNodeTests/PostgresJsonEditorTests.cs
@@ -17,9 +17,10 @@ public class PostgresJsonEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
 
-        queryNode.ToSubQuery("d");
 
-        var actual = queryNode.Query.ToSql();
+        var newQueryNode = queryNode.ToSubQuery("d");
+
+        var actual = newQueryNode.Query.ToSql();
         output.WriteLine(actual);
 
         var expected = "select d.user_id, d.name from (select users.user_id, users.name from users) as d";

--- a/tests/Carbunqlex.Tests/QueryNodeTests/WhereEditorTests.cs
+++ b/tests/Carbunqlex.Tests/QueryNodeTests/WhereEditorTests.cs
@@ -74,7 +74,7 @@ public class WhereEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
 
-        queryNode.Where("table_a_id", static value => value.In(1, 2, 3).NotIn(4, 5, 6));
+        queryNode.Where("table_a_id", static value => value.In([1, 2, 3]).NotIn([4, 5, 6]));
 
         var actual = queryNode.Query.ToSql();
         output.WriteLine(actual);

--- a/tests/Carbunqlex.Tests/ValueExpressionTests/ValueExpressionTests.cs
+++ b/tests/Carbunqlex.Tests/ValueExpressionTests/ValueExpressionTests.cs
@@ -97,7 +97,7 @@ public class ValueExpressionTests(ITestOutputHelper output)
         var left = new ColumnExpression("TableName", "ColumnName");
         var right1 = new LiteralExpression(1);
         var right2 = new LiteralExpression(2);
-        var inExpression = ValueBuilder.In(left, new ValueArguments(right1, right2));
+        var inExpression = ValueBuilder.In(new InValueGroupExpression(left), new InValueGroupExpression(right1, right2));
         var sql = inExpression.ToSqlWithoutCte();
         output.WriteLine(sql);
         Assert.Equal("TableName.ColumnName in (1, 2)", sql);
@@ -109,7 +109,7 @@ public class ValueExpressionTests(ITestOutputHelper output)
         var left = new ColumnExpression("TableName", "ColumnName");
         var right1 = new LiteralExpression(1);
         var right2 = new LiteralExpression(2);
-        var inExpression = ValueBuilder.NotIn(left, new ValueArguments(right1, right2));
+        var inExpression = ValueBuilder.NotIn(new InValueGroupExpression(left), new InValueGroupExpression(right1, right2));
         var sql = inExpression.ToSqlWithoutCte();
         output.WriteLine(sql);
         Assert.Equal("TableName.ColumnName not in (1, 2)", sql);


### PR DESCRIPTION
- Fixed bug where multiple columns could not be specified in an IN clause.
- Add `ToDeleteQuery` method in `QueryNode` for generating delete queries based on table name, with options for subquery alias, returning, and key columns.
- Update `ToSubQuery` method to allow specifying selected columns and filter expressions.
- Introduce overloaded method in `QueryNodeFactory` to create `QueryNode` from SQL string.