### PR TITLE
Add constructors and update query handling

### DIFF
--- a/src/Carbunqlex/Clauses/UpdateClause.cs
+++ b/src/Carbunqlex/Clauses/UpdateClause.cs
@@ -9,6 +9,12 @@ public class UpdateClause : ISqlComponent
 
     public string Alias { get; set; }
 
+    public UpdateClause(TableSource tableSource)
+    {
+        TableSource = tableSource;
+        Alias = tableSource.DefaultName;
+    }
+
     public UpdateClause(TableSource tableSource, string alias)
     {
         TableSource = tableSource;
@@ -46,6 +52,11 @@ public class SetClause : ISqlComponent
 {
     public List<SetExpression> SetExpressions { get; set; }
 
+    public SetClause()
+    {
+        SetExpressions = new List<SetExpression>();
+    }
+
     public SetClause(List<SetExpression> setExpressions)
     {
         SetExpressions = setExpressions;
@@ -77,6 +88,11 @@ public class SetClause : ISqlComponent
                 yield return query;
             }
         }
+    }
+
+    public void Add(SetExpression setExpression)
+    {
+        SetExpressions.Add(setExpression);
     }
 }
 

--- a/src/Carbunqlex/DeleteQuery.cs
+++ b/src/Carbunqlex/DeleteQuery.cs
@@ -53,7 +53,21 @@ public class DeleteQuery : IQuery
             sb.Append(withSql).Append(" ");
         }
 
-        sb.Append(ToSqlWithoutCte());
+        sb.Append(DeleteClause.ToSqlWithoutCte());
+        if (UsingClause != null)
+        {
+            sb.Append(" ").Append(UsingClause.ToSqlWithoutCte());
+        }
+        var whereSql = WhereClause.ToSqlWithoutCte();
+        if (!string.IsNullOrEmpty(whereSql))
+        {
+            sb.Append(" ").Append(whereSql);
+        }
+        if (ReturningClause != null)
+        {
+            sb.Append(" ").Append(ReturningClause.ToSqlWithoutCte());
+        }
+
         return sb.ToString();
     }
 
@@ -113,41 +127,12 @@ public class DeleteQuery : IQuery
 
     public string ToSqlWithoutCte()
     {
-        var sb = new StringBuilder($"{DeleteClause.ToSqlWithoutCte()}");
-        if (UsingClause != null)
-        {
-            sb.Append(" ").Append(UsingClause.ToSqlWithoutCte());
-        }
-        var whereSql = WhereClause.ToSqlWithoutCte();
-        if (!string.IsNullOrEmpty(whereSql))
-        {
-            sb.Append(" ").Append(whereSql);
-        }
-        if (ReturningClause != null)
-        {
-            sb.Append(" ").Append(ReturningClause.ToSqlWithoutCte());
-        }
-
-        return sb.ToString();
+        throw new InvalidOperationException("If CTEs are omitted, the query may be incomplete. Please use the ToSql method.");
     }
 
     public IEnumerable<Token> GenerateTokensWithoutCte()
     {
-        foreach (var token in DeleteClause.GenerateTokensWithoutCte())
-        {
-            yield return token;
-        }
-        foreach (var token in WhereClause.GenerateTokensWithoutCte())
-        {
-            yield return token;
-        }
-        if (ReturningClause != null)
-        {
-            foreach (var token in ReturningClause.GenerateTokensWithoutCte())
-            {
-                yield return token;
-            }
-        }
+        throw new InvalidOperationException("If CTEs are omitted, the query may be incomplete. Please use the ToSql method.");
     }
 
     public IEnumerable<ISelectQuery> GetQueries()

--- a/src/Carbunqlex/ValueExpressions/ColumnExpression.cs
+++ b/src/Carbunqlex/ValueExpressions/ColumnExpression.cs
@@ -17,7 +17,14 @@ public class ColumnExpression : IValueExpression
 
     public ColumnExpression(string tableName, string columnName)
     {
-        Namespaces = new List<string> { tableName };
+        if (!string.IsNullOrEmpty(tableName))
+        {
+            Namespaces = new List<string> { tableName };
+        }
+        else
+        {
+            Namespaces = new List<string>();
+        }
         ColumnName = columnName;
     }
 

--- a/tests/Carbunqlex.Tests/ParsingTests/InsertQueryParserTest.cs
+++ b/tests/Carbunqlex.Tests/ParsingTests/InsertQueryParserTest.cs
@@ -18,7 +18,7 @@ public class InsertQueryParserTest
     {
         var sql = "insert into table_name(column1, column2) values (1, 'value')";
         var result = InsertQueryParser.Parse(sql);
-        var actual = result.ToSqlWithoutCte();
+        var actual = result.ToSql();
         Output.WriteLine(actual);
         Assert.Equal("insert into table_name(column1, column2) values (1, 'value')", actual);
     }
@@ -28,7 +28,7 @@ public class InsertQueryParserTest
     {
         var sql = "insert into table_name(column1, column2) values (1, 'value') returning id";
         var result = InsertQueryParser.Parse(sql);
-        var actual = result.ToSqlWithoutCte();
+        var actual = result.ToSql();
         Output.WriteLine(actual);
         Assert.Equal("insert into table_name(column1, column2) values (1, 'value') returning id", actual);
     }
@@ -38,7 +38,7 @@ public class InsertQueryParserTest
     {
         var sql = "insert into table_name(column1, column2) select column1, column2 from other_table";
         var result = InsertQueryParser.Parse(sql);
-        var actual = result.ToSqlWithoutCte();
+        var actual = result.ToSql();
         Output.WriteLine(actual);
         Assert.Equal("insert into table_name(column1, column2) select column1, column2 from other_table", actual);
     }

--- a/tests/Carbunqlex.Tests/QueryNodeTests/SelectEditorTests.cs
+++ b/tests/Carbunqlex.Tests/QueryNodeTests/SelectEditorTests.cs
@@ -74,9 +74,9 @@ public class SelectEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
 
-        var insertQuery = queryNode.ToInsertQuery("table_b", true, "sequence_column1", "sequence_column2");
+        var insertQuery = queryNode.ToInsertQuery("table_b", sequenceColumns: ["sequence_column1", "sequence_column2"], hasReturning: true);
 
-        var actual = insertQuery.ToSqlWithoutCte();
+        var actual = insertQuery.ToSql();
         output.WriteLine(actual);
 
         var expected = "insert into table_b(table_a_id, value) select a.table_a_id, a.value from table_a as a returning sequence_column1, sequence_column2, table_a_id, value";
@@ -95,10 +95,25 @@ public class SelectEditorTests(ITestOutputHelper output)
 
         var insertQuery = queryNode.ToInsertQuery("table_b");
 
-        var actual = insertQuery.ToSqlWithoutCte();
+        var actual = insertQuery.ToSql();
         output.WriteLine(actual);
 
         var expected = "insert into table_b(table_a_id, value) select a.table_a_id, a.value from table_a as a";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToInsertQueryWithCteTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("WITH cte AS (SELECT post_id FROM posts) SELECT post_id FROM cte");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var insertQuery = queryNode.ToInsertQuery("table_b");
+        var actual = insertQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "insert into table_b(post_id) with cte as (select post_id from posts) select post_id from cte";
         Assert.Equal(expected, actual);
     }
 
@@ -112,9 +127,9 @@ public class SelectEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
 
-        var insertQuery = queryNode.ToInsertQuery("table_b", true, "sequence_column1");
+        var insertQuery = queryNode.ToInsertQuery("table_b", sequenceColumns: ["sequence_column1"], hasReturning: true);
 
-        var actual = insertQuery.ToSqlWithoutCte();
+        var actual = insertQuery.ToSql();
         output.WriteLine(actual);
 
         var expected = "insert into table_b(table_a_id, value) select a.table_a_id, a.value from table_a as a returning sequence_column1, table_a_id, value";
@@ -131,9 +146,9 @@ public class SelectEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
 
-        var insertQuery = queryNode.ToInsertQuery("table_b", true, "sequence_column1");
+        var insertQuery = queryNode.ToInsertQuery("table_b", sequenceColumns: ["sequence_column1"], hasReturning: true);
 
-        var actual = insertQuery.ToSqlWithoutCte();
+        var actual = insertQuery.ToSql();
         output.WriteLine(actual);
 
         var expected = "insert into table_b(id, val) select a.table_a_id as id, a.value as val from table_a as a returning sequence_column1, id, val";
@@ -141,17 +156,98 @@ public class SelectEditorTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void ToDeleteQueryTest()
+    public void ToInsertQueryWithValueFilter()
     {
         // Arrange
-        var query = SelectQueryParser.Parse("select a.v1 as value_1, a.value_2 from table_a as a where a.price = 1");
+        var query = SelectQueryParser.Parse("select a.table_a_id, a.value1, a.value2 from table_a as a where a.table_a_id = 1");
+
         // Act
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
-        var deleteQuery = queryNode.ToDeleteQuery("table_x");
-        var actual = deleteQuery.ToSqlWithoutCte();
+
+        var insertQuery = queryNode.ToInsertQuery("table_b", valueColumns: ["value2"]);
+
+        var actual = insertQuery.ToSql();
         output.WriteLine(actual);
-        var expected = "delete from table_x where (table_x.value_1, table_x.value_2) in (select q.value_1, q.value_2 from (select a.v1 as value_1, a.value_2 from table_a as a where a.price = 1) as q)";
+
+        var expected = "insert into table_b(value2) select q.value2 from (select a.table_a_id, a.value1, a.value2 from table_a as a where a.table_a_id = 1) as q";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToUpdateQueryTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("select a.table_a_id, a.value from table_a as a where a.price = 1");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+
+        var updateQuery = queryNode.ToUpdateQuery("table_b", ["table_a_id"]);
+        var actual = updateQuery.ToSql();
+        output.WriteLine(actual);
+
+        var expected = "update table_b set value = q.value from (select a.table_a_id, a.value from table_a as a where a.price = 1) as q where table_b.table_a_id = q.table_a_id";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToUpdateQueryWithReturningTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("select a.table_a_id, a.value from table_a as a where a.price = 1");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var updateQuery = queryNode.ToUpdateQuery("table_b", ["table_a_id"], hasReturning: true);
+        var actual = updateQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "update table_b set value = q.value from (select a.table_a_id, a.value from table_a as a where a.price = 1) as q where table_b.table_a_id = q.table_a_id returning *";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToUpdateQueryWithCteTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("WITH cte AS (SELECT post_id, value FROM posts) SELECT post_id, value FROM cte");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var updateQuery = queryNode.ToUpdateQuery("table_b", ["post_id"]);
+        var actual = updateQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "with cte as (select post_id, value from posts) update table_b set value = q.value from (select post_id, value from cte) as q where table_b.post_id = q.post_id";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToUpdateQueryWithKeyColumnTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("select a.table_a_id, a.value from table_a as a where a.table_a_id = 1");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var updateQuery = queryNode.ToUpdateQuery("table_b", ["table_a_id"]);
+        var actual = updateQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "update table_b set value = q.value from (select a.table_a_id, a.value from table_a as a where a.table_a_id = 1) as q where table_b.table_a_id = q.table_a_id";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToUpdateQueryWithValueFilter()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("select a.table_a_id, a.value1, a.value2 from table_a as a where a.table_a_id = 1");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var updateQuery = queryNode.ToUpdateQuery("table_b", ["table_a_id"], valueColumns: ["value2"]);
+        var actual = updateQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "update table_b set value2 = q.value2 from (select a.table_a_id, a.value1, a.value2 from table_a as a where a.table_a_id = 1) as q where table_b.table_a_id = q.table_a_id";
         Assert.Equal(expected, actual);
     }
 
@@ -163,8 +259,8 @@ public class SelectEditorTests(ITestOutputHelper output)
         // Act
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
-        var updateQuery = queryNode.ToDeleteQuery("table_x", hasReturning: true);
-        var actual = updateQuery.ToSqlWithoutCte();
+        var deleteQuery = queryNode.ToDeleteQuery("table_x", hasReturning: true);
+        var actual = deleteQuery.ToSql();
         output.WriteLine(actual);
         var expected = "delete from table_x where (table_x.value_1, table_x.value_2) in (select q.value_1, q.value_2 from (select a.v1 as value_1, a.value_2 from table_a as a where a.price = 1) as q) returning *";
         Assert.Equal(expected, actual);
@@ -179,9 +275,24 @@ public class SelectEditorTests(ITestOutputHelper output)
         var queryNode = QueryNodeFactory.Create(query);
         output.WriteLine(queryNode.Query.ToSql());
         var deleteQuery = queryNode.ToDeleteQuery("table_b", keyColumns: ["table_a_id"]);
-        var actual = deleteQuery.ToSqlWithoutCte();
+        var actual = deleteQuery.ToSql();
         output.WriteLine(actual);
         var expected = "delete from table_b where table_b.table_a_id in (select q.table_a_id from (select a.table_a_id, a.value from table_a as a where a.table_a_id = 1) as q)";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToDeleteQueryCte()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("WITH cte AS (SELECT post_id FROM posts) SELECT post_id FROM cte");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var deleteQuery = queryNode.ToDeleteQuery("table_b");
+        var actual = deleteQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "with cte as (select post_id from posts) delete from table_b where table_b.post_id in (select q.post_id from (select post_id from cte) as q)";
         Assert.Equal(expected, actual);
     }
 
@@ -212,6 +323,21 @@ public class SelectEditorTests(ITestOutputHelper output)
         var actual = createTableAsQuery.ToSql();
         output.WriteLine(actual);
         var expected = "create temporary table table_b as select a.table_a_id, a.value from table_a as a";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ToCreateTableQueryWithCteTest()
+    {
+        // Arrange
+        var query = SelectQueryParser.Parse("WITH cte AS (SELECT post_id FROM posts) SELECT post_id FROM cte");
+        // Act
+        var queryNode = QueryNodeFactory.Create(query);
+        output.WriteLine(queryNode.Query.ToSql());
+        var createTableAsQuery = queryNode.ToCreateTableQuery("table_b", false);
+        var actual = createTableAsQuery.ToSql();
+        output.WriteLine(actual);
+        var expected = "create table table_b as with cte as (select post_id from posts) select post_id from cte";
         Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
- Added ToUpdateQuery method to QueryNode for generating update queries.
- Added constructor to UpdateClause for initializing TableSource and Alias.
- Default constructor added to SetClause, initializing SetExpressions as an empty list.
- Added Add method to SetClause for adding SetExpression.
- Modified DeleteQuery's ToSqlWithoutCte to throw an exception if CTEs are omitted.
- Updated InsertQuery's ToSqlWithoutCte to throw an exception if CTEs are omitted.
- Changed InsertQuery's ToSql to use InsertClause's ToSql method instead of ToSqlWithoutCte.
- Changed argument order in QueryNode's ToDeleteQuery method.