### PR TITLE
Improve token parsing and handling in SQL parser

### DIFF
--- a/src/Carbunqlex/Parsing/OrderByColumnParser.cs
+++ b/src/Carbunqlex/Parsing/OrderByColumnParser.cs
@@ -21,11 +21,11 @@ public class OrderByColumnParser
             return true;
         }
 
-        var next = tokenizer.Peek(token => token.CommandOrOperatorText);
+        var next = tokenizer.Peek().CommandOrOperatorText;
 
         if (next == "asc" || next == "desc")
         {
-            tokenizer.Read();
+            tokenizer.CommitPeek();
             return next == "asc";
         }
 
@@ -39,7 +39,7 @@ public class OrderByColumnParser
             return null;
         }
 
-        var next = tokenizer.Peek(token => token.CommandOrOperatorText);
+        var next = tokenizer.Peek().CommandOrOperatorText;
 
         if (next == "nulls first" || next == "nulls last")
         {

--- a/src/Carbunqlex/Parsing/SqlKeyword.cs
+++ b/src/Carbunqlex/Parsing/SqlKeyword.cs
@@ -94,6 +94,11 @@ public static class SqlKeyword
 
         CommandKeywords = new HashSet<string>
         {
+            "position",
+            "trim",
+            "both",
+            "trailing",
+            "leading",
             //common
             "as",
             //with

--- a/src/Carbunqlex/Parsing/ValueArgumentsParser.cs
+++ b/src/Carbunqlex/Parsing/ValueArgumentsParser.cs
@@ -17,28 +17,26 @@ public static class ValueArgumentsParser
             if (tokenizer.TryPeek(out var comma) && comma.Type == TokenType.Comma)
             {
                 tokenizer.Read();
-                continue; ;
+                continue;
             }
             break;
         }
 
-        return tokenizer.Peek(token =>
+        var next = tokenizer.Peek();
+
+        if (next.Type == closeToken)
         {
-            if (token.Type == closeToken)
-            {
-                tokenizer.Read();
-                return new ArgumentExpression(args);
-            }
+            tokenizer.Read();
+            return new ArgumentExpression(args);
+        }
 
-            if (token.CommandOrOperatorText == "order by")
-            {
-                var orderByClause = OrderByClauseParser.Parse(tokenizer);
-                var expression = new ArgumentExpression(args) { OrderByClause = orderByClause };
-                tokenizer.Read(closeToken);
-                return expression;
-            }
+        if (next.CommandOrOperatorText == "order by")
+        {
+            var orderByClause = OrderByClauseParser.Parse(tokenizer);
+            tokenizer.Read(closeToken);
+            return new ArgumentExpression(args) { OrderByClause = orderByClause };
+        }
 
-            throw SqlParsingExceptionBuilder.UnexpectedToken(tokenizer, [closeToken.ToString(), "order by"], token);
-        });
+        throw SqlParsingExceptionBuilder.UnexpectedToken(tokenizer, [closeToken.ToString(), "order by"], next);
     }
 }

--- a/src/Carbunqlex/Parsing/ValueExpression/CaseExpressionParser.cs
+++ b/src/Carbunqlex/Parsing/ValueExpression/CaseExpressionParser.cs
@@ -9,9 +9,9 @@ public static class CaseExpressionParser
     {
         tokenizer.Read("case");
 
-        var caseValue = tokenizer.Peek(token =>
+        var caseValue = tokenizer.Peek(static (r, token) =>
         {
-            return token.CommandOrOperatorText == "when" ? null : ValueExpressionParser.Parse(tokenizer);
+            return token.CommandOrOperatorText == "when" ? null : ValueExpressionParser.Parse(r);
         }, null);
 
         var whenClauses = ParseWhenThenPair(tokenizer).ToList();


### PR DESCRIPTION
- Introduced switch statements in `ReadOnlyMemoryExtensions.cs` for streamlined token processing.
- Enhanced token reading and state management in `SqlTokenizer.cs` for better performance and readability.
- Analysis speed has improved by about 10%.

## before
| Method                         | Mean       | Error     | StdDev    |
|------------------------------- |-----------:|----------:|----------:|
| Carbunqlex_Parse_Short         |   8.410 μs | 0.0409 μs | 0.0363 μs |
| Carbunqlex_ParseOnly_Short     |   7.537 μs | 0.0313 μs | 0.0261 μs |
| Carbunqlex_Parse_Middle        |  24.017 μs | 0.1175 μs | 0.1041 μs |
| Carbunqlex_ParseOnly_Middle    |  22.081 μs | 0.0659 μs | 0.0514 μs |
| Carbunqlex_Parse_Long          |  44.607 μs | 0.2594 μs | 0.2166 μs |
| Carbunqlex_ParseOnly_Long      |  40.964 μs | 0.3165 μs | 0.2806 μs |
| Carbunqlex_Parse_SuperLong     |  94.404 μs | 0.4854 μs | 0.4053 μs |
| Carbunqlex_ParseOnly_SuperLong |  69.528 μs | 0.2361 μs | 0.1972 μs |


## after
| Method                         | Mean       | Error     | StdDev    |
|------------------------------- |-----------:|----------:|----------:|
| Carbunqlex_Parse_Short         |   7.530 μs | 0.0809 μs | 0.0717 μs |
| Carbunqlex_ParseOnly_Short     |   6.770 μs | 0.0197 μs | 0.0154 μs |
| Carbunqlex_Parse_Middle        |  21.180 μs | 0.0782 μs | 0.0610 μs |
| Carbunqlex_ParseOnly_Middle    |  19.101 μs | 0.1167 μs | 0.1034 μs |
| Carbunqlex_Parse_Long          |  40.113 μs | 0.2124 μs | 0.1774 μs |
| Carbunqlex_ParseOnly_Long      |  38.414 μs | 0.1544 μs | 0.1369 μs |
| Carbunqlex_Parse_SuperLong     |  85.758 μs | 0.8017 μs | 0.7107 μs |
| Carbunqlex_ParseOnly_SuperLong |  62.131 μs | 0.7448 μs | 0.6966 μs |
