### PR TITLE
Refactor character handling in CharExtensions and ReadOnlyMemoryExtensions

### DIFF
--- a/src/Carbunqlex/Parsing/CharExtenstions.cs
+++ b/src/Carbunqlex/Parsing/CharExtenstions.cs
@@ -2,68 +2,77 @@
 {
     internal static class CharExtenstions
     {
-        /// <summary>
-        /// Defines a set of characters considered as symbols that terminate an identifier.
-        /// </summary>
-        private static readonly HashSet<char> CharacterSymbols = new HashSet<char>
-        {
-            '(', ')', '[', ']', '{', '}', // Brackets and braces
-            '`', '"', '\'', // Quotation marks
-            '*', // Select all
-            ';', // Statement terminator
-        };
+        private static readonly char[] CharacterSymbols =
+        [
+                '(', ')', '[', ']', '{', '}', // Brackets and braces
+                '`', '"', '\'', // Quotation marks
+                '*', // Select all
+                ';', // Statement terminator
+        ];
 
-        /// <summary>
-        /// Defines a set of characters considered as symbols that terminate an identifier.
-        /// </summary>
-        private static readonly HashSet<char> MultipleSymbols = new HashSet<char>
-        {
-            '+', '-', '*', '/', '%', // Arithmetic operators
-            '~', '@', '#', '$', '^', '&', // Special symbols
-            '!', '?', ':', ',', '.', '<', '>', '=', '|', '\\', // Other symbols
-        };
+        private static readonly char[] MultipleSymbols =
+        [
+                '+', '-', '*', '/', '%', // Arithmetic operators
+                '~', '@', '#', '$', '^', '&', // Special symbols
+                '!', '?', ':', ',', '.', '<', '>', '=', '|', '\\', // Other symbols
+        ];
 
-        private static readonly HashSet<char> WhiteSpaces = new HashSet<char>
-        {
-            ' ', '\t', '\r', '\n',
-        };
+        private static readonly char[] WhiteSpaces =
+        [
+                ' ', '\t', '\r', '\n',
+        ];
 
-        private static readonly Dictionary<char, char> ValueEscapePairs = new Dictionary<char, char>
-        {
-            { '"', '"' }, // Double quote
-            { '[', ']' }, // Square brackets
-            { '`', '`' }  // Backquote
-        };
-
-        private static readonly Dictionary<char, char> LineEnds = new Dictionary<char, char>
-        {
-            { '\r', '\n' },
-            { '\n', '\r' }
-        };
-
-        public static bool TryGetDbmsValueEscapeChar(this char c, out char closeChar)
-        {
-            return ValueEscapePairs.TryGetValue(c, out closeChar);
-        }
+        private static readonly char[] LineEnds =
+        [
+                '\r', '\n'
+        ];
 
         public static bool IsWhiteSpace(this char c)
         {
-            return WhiteSpaces.Contains(c);
+            foreach (var ws in WhiteSpaces)
+            {
+                if (ws == c)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public static bool IsSingleSymbol(this char c)
         {
-            return CharacterSymbols.Contains(c);
+            foreach (var symbol in CharacterSymbols)
+            {
+                if (symbol == c)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public static bool IsMultipleSymbol(this char c)
         {
-            return MultipleSymbols.Contains(c);
+            foreach (var symbol in MultipleSymbols)
+            {
+                if (symbol == c)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public static bool IsLineEnd(this char c)
         {
-            return LineEnds.ContainsKey(c);
+            foreach (var le in LineEnds)
+            {
+                if (le == c)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/Carbunqlex/Parsing/ReadOnlyMemoryExtensions.cs
+++ b/src/Carbunqlex/Parsing/ReadOnlyMemoryExtensions.cs
@@ -400,11 +400,15 @@ public static class ReadOnlyMemoryExtensions
 
         if (ignoreCase)
         {
-            if (span.ToString().Equals(expectedValue, StringComparison.OrdinalIgnoreCase))
+            for (int i = 0; i < span.Length; i++)
             {
-                endPosition = start + expectedValue.Length;
-                return true;
+                if (char.ToLowerInvariant(span[i]) != char.ToLowerInvariant(expectedValue[i]))
+                {
+                    return false;
+                }
             }
+            endPosition = start + expectedValue.Length;
+            return true;
         }
         else
         {

--- a/src/Carbunqlex/Parsing/ReadOnlyMemoryExtensions.cs
+++ b/src/Carbunqlex/Parsing/ReadOnlyMemoryExtensions.cs
@@ -717,14 +717,14 @@ public static class ReadOnlyMemoryExtensions
         }
 
         // Check if the first character is not a letter
-        if (memory.Span[p].IsWhiteSpace() || memory.Span[p].IsSingleSymbol() || memory.Span[p].IsMultipleSymbol())
+        if (!IsValidWordCharacter(memory.Span[p]))
         {
             word = string.Empty;
             return false;
         }
 
-        //　Read until a white space or symbol is found
-        while (p < memory.Length && !memory.Span[p].IsWhiteSpace() && !memory.Span[p].IsSingleSymbol() && !memory.Span[p].IsMultipleSymbol())
+        // Read until a white space or symbol is found
+        while (p < memory.Length && IsValidWordCharacter(memory.Span[p]))
         {
             p++;
         }
@@ -732,6 +732,11 @@ public static class ReadOnlyMemoryExtensions
         word = memory.Slice(start, p - start).ToString();
         endPosition = p;
         return true;
+    }
+
+    private static bool IsValidWordCharacter(char c)
+    {
+        return !char.IsWhiteSpace(c) && !c.IsSingleSymbol() && !c.IsMultipleSymbol();
     }
 
     private static bool IsMultipleSymbol(this ReadOnlyMemory<char> memory, int position)


### PR DESCRIPTION
SQL parser optimized: achieved 15-25% performance gains and enhanced stability across all query lengths.

- Changed data structures from HashSet<char> to char[] for improved efficiency.
- Updated methods to use loops instead of Contains for better performance.

## before
| Method                         | Mean       | Error     | StdDev    |
|------------------------------- |-----------:|----------:|----------:|
| Carbunqlex_Parse_Short         |   7.530 μs | 0.0809 μs | 0.0717 μs |
| Carbunqlex_ParseOnly_Short     |   6.770 μs | 0.0197 μs | 0.0154 μs |
| Carbunqlex_Parse_Middle        |  21.180 μs | 0.0782 μs | 0.0610 μs |
| Carbunqlex_ParseOnly_Middle    |  19.101 μs | 0.1167 μs | 0.1034 μs |
| Carbunqlex_Parse_Long          |  40.113 μs | 0.2124 μs | 0.1774 μs |
| Carbunqlex_ParseOnly_Long      |  38.414 μs | 0.1544 μs | 0.1369 μs |
| Carbunqlex_Parse_SuperLong     |  85.758 μs | 0.8017 μs | 0.7107 μs |
| Carbunqlex_ParseOnly_SuperLong |  62.131 μs | 0.7448 μs | 0.6966 μs |

## after
| Method                         | Mean      | Error     | StdDev    |
|------------------------------- |----------:|----------:|----------:|
| Carbunqlex_Parse_Short         |  7.578 μs | 0.0345 μs | 0.0306 μs |
| Carbunqlex_ParseOnly_Short     |  6.487 μs | 0.0194 μs | 0.0162 μs |
| Carbunqlex_Parse_Middle        | 20.482 μs | 0.1782 μs | 0.1667 μs |
| Carbunqlex_ParseOnly_Middle    | 18.839 μs | 0.0808 μs | 0.0716 μs |
| Carbunqlex_Parse_Long          | 38.988 μs | 0.3077 μs | 0.2878 μs |
| Carbunqlex_ParseOnly_Long      | 35.014 μs | 0.3216 μs | 0.2851 μs |
| Carbunqlex_Parse_SuperLong     | 82.868 μs | 0.5076 μs | 0.4748 μs |
| Carbunqlex_ParseOnly_SuperLong | 55.696 μs | 0.4335 μs | 0.4055 μs |

## after2
| Method                         | Mean      | Error     | StdDev    |
|------------------------------- |----------:|----------:|----------:|
| Carbunqlex_Parse_Short         |  6.199 μs | 0.0160 μs | 0.0134 μs |
| Carbunqlex_ParseOnly_Short     |  5.432 μs | 0.0296 μs | 0.0247 μs |
| Carbunqlex_Parse_Middle        | 17.340 μs | 0.0881 μs | 0.0824 μs |
| Carbunqlex_ParseOnly_Middle    | 15.854 μs | 0.1539 μs | 0.1440 μs |
| Carbunqlex_Parse_Long          | 33.004 μs | 0.1898 μs | 0.1683 μs |
| Carbunqlex_ParseOnly_Long      | 29.729 μs | 0.2178 μs | 0.1930 μs |
| Carbunqlex_Parse_SuperLong     | 72.868 μs | 0.7630 μs | 0.6371 μs |
| Carbunqlex_ParseOnly_SuperLong | 46.911 μs | 0.2853 μs | 0.2669 μs |
