### PR TITLE
Update project file to support multiple frameworks

### DIFF
--- a/src/Carbunqlex/Carbunqlex.csproj
+++ b/src/Carbunqlex/Carbunqlex.csproj
@@ -1,12 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/mk3008/CarbunqleX</RepositoryUrl>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<FileVersion></FileVersion>
+		<Version>0.0.1</Version>
+		<Authors>mk3008net</Authors>
+		<Description>CarbunqleX is a lightweight library that enhances the reusability and maintainability of RawSQL through advanced AST analysis.</Description>
+		<Copyright>mk3008net</Copyright>
+		<PackageProjectUrl>https://github.com/mk3008/CarbunqleX</PackageProjectUrl>
+		<PackageTags>postgres;sql;postgresql;ast;sql-parser;raw-sql;dynamic-query;postgres-sql-parser</PackageTags>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
- Changed target framework from `net9.0` to `net8.0;net9.0`
- Added metadata: file version, version number, authors, description, copyright, project URL, and package tags
- Enhanced project information and support for multiple target frameworks