### PR TITLE
Performance Comparison: SqlScriptDOM vs. CarbunqleX

### DIFF
--- a/demo/Benchmark/Benchmark.csproj
+++ b/demo/Benchmark/Benchmark.csproj
@@ -11,8 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Carbunql" Version="0.8.14" />
-    <PackageReference Include="SqModel" Version="0.8.15" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.28.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Below are the benchmark results comparing the parsing speed and SQL output speed of SqlScriptDOM and CarbunqleX.
It is worth noting that SqlScriptDOM supports parsing DML statements as well, which inherently introduces additional overhead compared to CarbunqleX.

## Parse only
| Method                            | Mean       | Error     | StdDev    |
|---------------------------------- |-----------:|----------:|----------:|
| Carbunqlex_ParseOnly_Tokens_20    |   5.383 μs | 0.0157 μs | 0.0139 μs |
| SqlScriptDOM_ParseOnly_Tokens_20  |  36.219 μs | 0.2175 μs | 0.1928 μs |
| Carbunqlex_ParseOnly_Tokens_70    |  15.738 μs | 0.0267 μs | 0.0209 μs |
| SqlScriptDOM_ParseOnly_Tokens_70  |  69.986 μs | 0.5502 μs | 0.4877 μs |
| Carbunqlex_ParseOnly_Tokens_140   |  29.776 μs | 0.1406 μs | 0.1315 μs |
| SqlScriptDOM_ParseOnly_Tokens_140 | 119.683 μs | 0.5008 μs | 0.4182 μs |
| Carbunqlex_ParseOnly_Tokens_230   |  47.182 μs | 0.2650 μs | 0.2069 μs |
| SqlScriptDOM_ParseOnly_Tokens_230 | 176.525 μs | 1.4383 μs | 1.2010 μs |


## Parse and SQL export
| Method                            | Mean       | Error     | StdDev    |
|---------------------------------- |-----------:|----------:|----------:|
| Carbunqlex_Parse_Tokens_20        |   6.108 μs | 0.0162 μs | 0.0144 μs |
| SqlScriptDOM_Parse_Tokens_20      |  38.457 μs | 0.0780 μs | 0.0609 μs |
| Carbunqlex_Parse_Tokens_70        |  16.812 μs | 0.0398 μs | 0.0353 μs |
| SqlScriptDOM_Parse_Tokens_70      |  83.005 μs | 0.5574 μs | 0.4352 μs |
| Carbunqlex_Parse_Tokens_140       |  33.383 μs | 0.6159 μs | 0.5460 μs |
| SqlScriptDOM_Parse_Tokens_140     | 134.582 μs | 1.1241 μs | 0.9965 μs |
| Carbunqlex_Parse_Tokens_230       |  74.030 μs | 0.4910 μs | 0.4352 μs |
| SqlScriptDOM_Parse_Tokens_230     | 206.661 μs | 1.3766 μs | 1.2203 μs |

