### PR TITLE
Fixed a bug where data sources with dots were not parsed correctly.

### DIFF
--- a/src/Carbunqlex/Carbunqlex.csproj
+++ b/src/Carbunqlex/Carbunqlex.csproj
@@ -8,7 +8,7 @@
 		<RepositoryUrl>https://github.com/mk3008/CarbunqleX</RepositoryUrl>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<FileVersion></FileVersion>
-		<Version>0.0.3</Version>
+		<Version>0.0.4</Version>
 		<Authors>mk3008net</Authors>
 		<Description>CarbunqleX is a lightweight library that enhances the reusability and maintainability of RawSQL through advanced AST analysis.</Description>
 		<Copyright>mk3008net</Copyright>

--- a/tests/Carbunqlex.Tests/ParsingTests/SelectQueryParserTests.cs
+++ b/tests/Carbunqlex.Tests/ParsingTests/SelectQueryParserTests.cs
@@ -321,4 +321,34 @@ public class SelectQueryParserTests
         Output.WriteLine(actual);
         Assert.Equal("with max_users as (select max(user_id) as max_id from users) select id from (select max_id as id from max_users) as d", actual);
     }
+
+    [Fact]
+    public void ParseSelectQueryFromShcemaTable()
+    {
+        var sql = """
+            select * from pg_catalog.pg_user
+            """;
+        // Arrange
+        var tokenizer = new SqlTokenizer(sql);
+        // Act
+        var result = SelectQueryParser.Parse(tokenizer);
+        var actual = result.ToSql();
+        Output.WriteLine(actual);
+        Assert.Equal("select * from pg_catalog.pg_user", actual);
+    }
+
+    [Fact]
+    public void ParseSelectQueryFromShcemaFunction()
+    {
+        var sql = """
+            select * from pg_catalog.generate_series(1, 10)
+            """;
+        // Arrange
+        var tokenizer = new SqlTokenizer(sql);
+        // Act
+        var result = SelectQueryParser.Parse(tokenizer);
+        var actual = result.ToSql();
+        Output.WriteLine(actual);
+        Assert.Equal("select * from pg_catalog.generate_series(1, 10)", actual);
+    }
 }


### PR DESCRIPTION
- DatasourceParser now reads tokens ahead and correctly interprets the schema.
- Physical tables and function tables that contain schema names can now be parsed correctly.

The following SQL was confirmed to be parsed correctly.

```sql
select * from pg_catalog.pg_user
```
```sql
select * from pg_catalog.generate_series(1, 10)
```


